### PR TITLE
8285437: riscv: Fix MachNode size mismatch for MacroAssembler::verify_oops*

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -379,7 +379,10 @@ void MacroAssembler::verify_oop(Register reg, const char* s) {
   push_reg(RegSet::of(ra, t0, t1, c_rarg0), sp);
 
   mv(c_rarg0, reg); // c_rarg0 : x10
-  li(t0, (uintptr_t)(address)b);
+  // The length of the instruction sequence emitted should be independent
+  // of the values of the local char buffer address so that the size of mach
+  // nodes for scratch emit and normal emit matches.
+  mv(t0, (address)b);
 
   // call indirectly to solve generation ordering problem
   int32_t offset = 0;
@@ -415,7 +418,10 @@ void MacroAssembler::verify_oop_addr(Address addr, const char* s) {
     ld(x10, addr);
   }
 
-  li(t0, (uintptr_t)(address)b);
+  // The length of the instruction sequence emitted should be independent
+  // of the values of the local char buffer address so that the size of mach
+  // nodes for scratch emit and normal emit matches.
+  mv(t0, (address)b);
 
   // call indirectly to solve generation ordering problem
   int32_t offset = 0;


### PR DESCRIPTION
Please review this backport to riscv-port-jdk17u.
Backport of [JDK-8285437](https://bugs.openjdk.java.net/browse/JDK-8285437). Applies cleanly.

Testing:
- A normal springboot-helloworld program using -XX:+VerifyOops passed on qemu and unmacthed.
- Tier1 passed without new failure on unmacthed (release).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285437](https://bugs.openjdk.org/browse/JDK-8285437): riscv: Fix MachNode size mismatch for MacroAssembler::verify_oops*


### Reviewers
 * [Xiaolin Zheng](https://openjdk.org/census#xlinzheng) (@zhengxiaolinX - no project role)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk17u pull/5/head:pull/5` \
`$ git checkout pull/5`

Update a local copy of the PR: \
`$ git checkout pull/5` \
`$ git pull https://git.openjdk.org/riscv-port-jdk17u pull/5/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5`

View PR using the GUI difftool: \
`$ git pr show -t 5`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk17u/pull/5.diff">https://git.openjdk.org/riscv-port-jdk17u/pull/5.diff</a>

</details>
