### PR TITLE
8294083: RISC-V: Minimal build failed with --disable-precompiled-headers

### DIFF
--- a/src/hotspot/cpu/riscv/c1_Runtime1_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_Runtime1_riscv.cpp
@@ -34,6 +34,7 @@
 #include "compiler/oopMap.hpp"
 #include "gc/shared/cardTable.hpp"
 #include "gc/shared/cardTableBarrierSet.hpp"
+#include "gc/shared/collectedHeap.hpp"
 #include "interpreter/interpreter.hpp"
 #include "memory/universe.hpp"
 #include "nativeInst_riscv.hpp"

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -32,6 +32,7 @@
 #include "gc/shared/barrierSetAssembler.hpp"
 #include "gc/shared/cardTable.hpp"
 #include "gc/shared/cardTableBarrierSet.hpp"
+#include "gc/shared/collectedHeap.hpp"
 #include "interpreter/bytecodeHistogram.hpp"
 #include "interpreter/interpreter.hpp"
 #include "memory/resourceArea.hpp"

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -32,6 +32,7 @@
 #include "oops/oop.inline.hpp"
 #include "runtime/handles.hpp"
 #include "runtime/orderAccess.hpp"
+#include "runtime/safepoint.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/stubRoutines.hpp"
 #include "utilities/ostream.hpp"

--- a/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
@@ -26,6 +26,7 @@
 
 #include "precompiled.hpp"
 #include "asm/macroAssembler.inline.hpp"
+#include "classfile/javaClasses.hpp"
 #include "gc/shared/barrierSetAssembler.hpp"
 #include "interpreter/bytecodeHistogram.hpp"
 #include "interpreter/bytecodeTracer.hpp"


### PR DESCRIPTION
Please review this backport to riscv-port-jdk17u.
Backport of [JDK-8294083](https://bugs.openjdk.org/browse/JDK-8294083). 
Compared to the original patch, the addition of including the corresponding header (gc/shared/collectedHeap.hpp) fix the invalid use of incomplete type 'class CollectedHeap' as follows:
```
=== Output from failing command(s) repeated here ===
* For target hotspot_variant-minimal_libjvm_objs_c1_Runtime1_riscv.o:
/home/zifeihan/riscv-port-jdk17u/src/hotspot/cpu/riscv/c1_Runtime1_riscv.cpp: In static member function 'static OopMapSet* Runtime1::generate_code_for(Runtime1::StubID, StubAssembler*)':
/home/zifeihan/riscv-port-jdk17u/src/hotspot/cpu/riscv/c1_Runtime1_riscv.cpp:675:41: error: invalid use of incomplete type 'class CollectedHeap'
  675 |             !UseTLAB && Universe::heap()->supports_inline_contig_alloc()) {
      |                                         ^~
In file included from /home/zifeihan/riscv-port-jdk17u/src/hotspot/cpu/riscv/c1_Runtime1_riscv.cpp:38:
/home/zifeihan/riscv-port-jdk17u/src/hotspot/share/memory/universe.hpp:42:7: note: forward declaration of 'class CollectedHeap'
   42 | class CollectedHeap;
      |       ^~~~~~~~~~~~~
/home/zifeihan/riscv-port-jdk17u/src/hotspot/cpu/riscv/c1_Runtime1_riscv.cpp:804:41: error: invalid use of incomplete type 'class CollectedHeap'
  804 |         if (!UseTLAB && Universe::heap()->supports_inline_contig_alloc()) {
      |                                         ^~
In file included from /home/zifeihan/riscv-port-jdk17u/src/hotspot/cpu/riscv/c1_Runtime1_riscv.cpp:38:
/home/zifeihan/riscv-port-jdk17u/src/hotspot/share/memory/universe.hpp:42:7: note: forward declaration of 'class CollectedHeap'
   42 | class CollectedHeap;
      |       ^~~~~~~~~~~~~

```
In addition to that, we need [JDK-8295468](https://bugs.openjdk.org/browse/JDK-8295468) to fix the minimal build of fastdebug.
Testing: Minimal builds with this fix

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8294083](https://bugs.openjdk.org/browse/JDK-8294083): RISC-V: Minimal build failed with --disable-precompiled-headers
 * [JDK-8295468](https://bugs.openjdk.org/browse/JDK-8295468): RISC-V: Minimal builds are broken


### Reviewers
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk17u pull/6/head:pull/6` \
`$ git checkout pull/6`

Update a local copy of the PR: \
`$ git checkout pull/6` \
`$ git pull https://git.openjdk.org/riscv-port-jdk17u pull/6/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6`

View PR using the GUI difftool: \
`$ git pr show -t 6`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk17u/pull/6.diff">https://git.openjdk.org/riscv-port-jdk17u/pull/6.diff</a>

</details>
