### PR TITLE
8296771: RISC-V: C2: assert(false) failed: bad AD file

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -3184,6 +3184,7 @@ operand iRegP()
   match(RegP);
   match(iRegPNoSp);
   match(iRegP_R10);
+  match(iRegP_R15);
   match(javaThread_RegP);
   op_cost(0);
   format %{ %}


### PR DESCRIPTION
Please review this backport to riscv-port-jdk17u.
Backport of [JDK-8296771](https://bugs.openjdk.org/browse/JDK-8296771). Applies cleanly. 
By the way, we can directly use` compiler/types/TestSubTypeCheckMacroTrichotomy.java` to reproduce the bad ad file error.

Testing:
- compiler/types/TestSubTypeCheckMacroTrichotomy.java passed on qemu/unmatched (fastdebug).
- Tier1 passed without new failure on unmacthed (release).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296771](https://bugs.openjdk.org/browse/JDK-8296771): RISC-V: C2: assert(false) failed: bad AD file


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk17u pull/8/head:pull/8` \
`$ git checkout pull/8`

Update a local copy of the PR: \
`$ git checkout pull/8` \
`$ git pull https://git.openjdk.org/riscv-port-jdk17u pull/8/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8`

View PR using the GUI difftool: \
`$ git pr show -t 8`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk17u/pull/8.diff">https://git.openjdk.org/riscv-port-jdk17u/pull/8.diff</a>

</details>
