### PR TITLE
8287970: riscv: jdk/incubator/vector/*VectorTests failing

### DIFF
--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -96,6 +96,7 @@ source %{
       case Op_VectorReinterpret:
       case Op_VectorStoreMask:
       case Op_VectorTest:
+      case Op_PopCountVI:
         return false;
       default:
         return UseRVV;
@@ -790,18 +791,6 @@ instruct vnegD(vReg dst, vReg src) %{
   ins_encode %{
     __ vsetvli(t0, x0, Assembler::e64);
     __ vfneg_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-// popcount vector
-
-instruct vpopcountI(iRegINoSp dst, vReg src) %{
-  match(Set dst (PopCountVI src));
-  format %{ "vpopc.m $dst, $src\t#@vpopcountI" %}
-  ins_encode %{
-    __ vsetvli(t0, x0, Assembler::e32);
-    __ vpopc_m(as_Register($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
 %}


### PR DESCRIPTION
Please review this backport to riscv-port-jdk17u.
Backport of [JDK-8287970](https://bugs.openjdk.org/browse/JDK-8287970). compared with the original patch, there is less to add Op_PopCountVL to the list of unsupported vectors.

Note that the vector operation VectorOperations.BIT_COUNT has not been introduced in this version, so even if the node Op_PopCountVI exists, it will not cause the test case to fail. Also, the node Op_PopCountVL has not been introduced in this version, so there is no need to add this node to the list of unsupported vectors.

Testing:
- test/jdk/jdk/incubator/vector (release/fastdebug on qemu with UseRVV)
- Tier1 passed without new failure on unmacthed (release).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287970](https://bugs.openjdk.org/browse/JDK-8287970): riscv: jdk/incubator/vector/*VectorTests failing


### Reviewers
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk17u pull/11/head:pull/11` \
`$ git checkout pull/11`

Update a local copy of the PR: \
`$ git checkout pull/11` \
`$ git pull https://git.openjdk.org/riscv-port-jdk17u pull/11/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11`

View PR using the GUI difftool: \
`$ git pr show -t 11`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk17u/pull/11.diff">https://git.openjdk.org/riscv-port-jdk17u/pull/11.diff</a>

</details>
