### PR TITLE
8291947: riscv: fail to build after JDK-8290840

### DIFF
--- a/src/hotspot/cpu/riscv/icache_riscv.cpp
+++ b/src/hotspot/cpu/riscv/icache_riscv.cpp
@@ -30,7 +30,7 @@
 #define __ _masm->
 
 static int icache_flush(address addr, int lines, int magic) {
-  os::icache_flush((long int) addr, (long int) (addr + (lines << ICache::log2_line_size)));
+  __builtin___clear_cache(addr, addr + (lines << ICache::log2_line_size));
   return magic;
 }
 

--- a/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.hpp
+++ b/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.hpp
@@ -37,23 +37,4 @@
     *(jlong *) dst = *(const jlong *) src;
   }
 
-  // SYSCALL_RISCV_FLUSH_ICACHE is used to flush instruction cache. The "fence.i" instruction
-  // only work on the current hart, so kernel provides the icache flush syscall to flush icache
-  // on each hart. You can pass a flag to determine a global or local icache flush.
-  static void icache_flush(long int start, long int end)
-  {
-    const int SYSCALL_RISCV_FLUSH_ICACHE = 259;
-    register long int __a7 asm ("a7") = SYSCALL_RISCV_FLUSH_ICACHE;
-    register long int __a0 asm ("a0") = start;
-    register long int __a1 asm ("a1") = end;
-    // the flush can be applied to either all threads or only the current.
-    // 0 means a global icache flush, and the icache flush will be applied
-    // to other harts concurrently executing.
-    register long int __a2 asm ("a2") = 0;
-    __asm__ volatile ("ecall\n\t"
-                      : "+r" (__a0)
-                      : "r" (__a0), "r" (__a1), "r" (__a2), "r" (__a7)
-                      : "memory");
-  }
-
 #endif // OS_CPU_LINUX_RISCV_VM_OS_LINUX_RISCV_HPP


### PR DESCRIPTION
Please review this backport to riscv-port-jdk17u.
Backport of [JDK-8291947](https://bugs.openjdk.org/browse/JDK-8291947). 
In the current version, https://bugs.openjdk.org/browse/JDK-8290840 has not been refactored, so the issues corresponding to the original issue do not exist. compared to the original patch, the icache_flush function is removed in a different location.

Testing:
- Tier1 passed without new failure on unmacthed (release).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291947](https://bugs.openjdk.org/browse/JDK-8291947): riscv: fail to build after JDK-8290840


### Reviewers
 * [Vladimir Kempik](https://openjdk.org/census#vkempik) (@VladimirKempik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk17u pull/15/head:pull/15` \
`$ git checkout pull/15`

Update a local copy of the PR: \
`$ git checkout pull/15` \
`$ git pull https://git.openjdk.org/riscv-port-jdk17u pull/15/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15`

View PR using the GUI difftool: \
`$ git pr show -t 15`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk17u/pull/15.diff">https://git.openjdk.org/riscv-port-jdk17u/pull/15.diff</a>

</details>
