### PR TITLE
8287425: Remove unnecessary register push for MacroAssembler::check_klass_subtype_slow_path

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2646,7 +2646,7 @@ void MacroAssembler::check_klass_subtype_slow_path(Register sub_klass,
     pushed_registers += x15;
   }
 
-  if (super_klass != x10 || UseCompressedOops) {
+  if (super_klass != x10) {
     if (!IS_A_TEMP(x10)) {
       pushed_registers += x10;
     }


### PR DESCRIPTION
This is another-half backport (RISC-V part only) of [JDK-8287425](https://bugs.openjdk.org/browse/JDK-8287425). The original patch is at [1].

This patch can interestingly fix an issue with async-profiler [2], and has been backported to JDK17/JDK11u. But when backporting to JDK17, the RISC-V part of this patch was dropped [3] since we did not have the RISC-V backend. Now that we have the RISC-V port of JDK17, the missing part needs a backport as well.

Tested on unmatched, hotspot tier1\~2 (fastdebug). More tiers are on the way.

[1] https://github.com/openjdk/jdk/commit/b5a646ee6cfd432cef6b7e69a177959227a38ace
[2] https://github.com/jvm-profiling-tools/async-profiler/issues/673#issuecomment-1316738564
[3] https://github.com/openjdk/jdk17u-dev/pull/672

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287425](https://bugs.openjdk.org/browse/JDK-8287425): Remove unnecessary register push for MacroAssembler::check_klass_subtype_slow_path


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk17u pull/16/head:pull/16` \
`$ git checkout pull/16`

Update a local copy of the PR: \
`$ git checkout pull/16` \
`$ git pull https://git.openjdk.org/riscv-port-jdk17u pull/16/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16`

View PR using the GUI difftool: \
`$ git pr show -t 16`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk17u/pull/16.diff">https://git.openjdk.org/riscv-port-jdk17u/pull/16.diff</a>

</details>
