### PR TITLE
Backport 3ad6aef1496de914b70f00005465e4b22f248d4f

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -9857,6 +9857,25 @@ instruct cmovI_cmpL(iRegINoSp dst, iRegI src, iRegL op1, iRegL op2, cmpOp cop) %
   ins_pipe(pipe_slow);
 %}
 
+instruct cmovI_cmpUL(iRegINoSp dst, iRegI src, iRegL op1, iRegL op2, cmpOpU cop) %{
+  match(Set dst (CMoveI (Binary cop (CmpUL op1 op2)) (Binary dst src)));
+  ins_cost(ALU_COST + BRANCH_COST);
+
+  format %{
+             "bneg$cop $op1, $op2, skip\t#@cmovI_cmpUL\n\t"
+             "mv $dst, $src\n\t"
+             "skip:"
+         %}
+
+  ins_encode %{
+    __ enc_cmove($cop$$cmpcode | C2_MacroAssembler::unsigned_branch_mask,
+                 as_Register($op1$$reg), as_Register($op2$$reg),
+                 as_Register($dst$$reg), as_Register($src$$reg));
+  %}
+
+  ins_pipe(pipe_slow);
+%}
+
 instruct cmovL_cmpL(iRegLNoSp dst, iRegL src, iRegL op1, iRegL op2, cmpOp cop) %{
   match(Set dst (CMoveL (Binary cop (CmpL op1 op2)) (Binary dst src)));
   ins_cost(ALU_COST + BRANCH_COST);
@@ -9895,11 +9914,30 @@ instruct cmovL_cmpUL(iRegLNoSp dst, iRegL src, iRegL op1, iRegL op2, cmpOpU cop)
   ins_pipe(pipe_slow);
 %}
 
-instruct cmovI_cmpUL(iRegINoSp dst, iRegI src, iRegL op1, iRegL op2, cmpOpU cop) %{
-  match(Set dst (CMoveI (Binary cop (CmpUL op1 op2)) (Binary dst src)));
+instruct cmovL_cmpI(iRegLNoSp dst, iRegL src, iRegI op1, iRegI op2, cmpOp cop) %{
+  match(Set dst (CMoveL (Binary cop (CmpI op1 op2)) (Binary dst src)));
   ins_cost(ALU_COST + BRANCH_COST);
   format %{
-             "bneg$cop $op1, $op2\t#@cmovI_cmpUL\n\t"
+             "bneg$cop $op1, $op2\t#@cmovL_cmpI\n\t"
+             "mv $dst, $src\n\t"
+             "skip:"
+         %}
+
+  ins_encode %{
+    __ enc_cmove($cop$$cmpcode,
+                 as_Register($op1$$reg), as_Register($op2$$reg),
+                 as_Register($dst$$reg), as_Register($src$$reg));
+  %}
+
+  ins_pipe(pipe_slow);
+%}
+
+instruct cmovL_cmpU(iRegLNoSp dst, iRegL src, iRegI op1, iRegI op2, cmpOpU cop) %{
+  match(Set dst (CMoveL (Binary cop (CmpU op1 op2)) (Binary dst src)));
+  ins_cost(ALU_COST + BRANCH_COST);
+
+  format %{
+             "bneg$cop $op1, $op2\t#@cmovL_cmpU\n\t"
              "mv $dst, $src\n\t"
              "skip:"
          %}
@@ -9912,7 +9950,6 @@ instruct cmovI_cmpUL(iRegINoSp dst, iRegI src, iRegL op1, iRegL op2, cmpOpU cop)
 
   ins_pipe(pipe_slow);
 %}
-
 
 // ============================================================================
 // Procedure Call/Return Instructions


### PR DESCRIPTION
Please review this backport to riscv-port-jdk17u.
Backport of [JDK-8301313](https://bugs.openjdk.org/browse/JDK-8301313). 
Compared to the original patch, jdk17u does not have the patche [JDK-8293290](https://bugs.openjdk.org/browse/JDK-8293290), so format and ins_pipe of some nodes will be slightly different.
The error `C2: assert(false) failed` mentioned in the original issue may require foreign api to reproduce, which is not available in jdk17u, but the same problem actually exists in jdk17u.


Testing:

Tier1-3 passed without new failure on unmacthed (release).

