### PR TITLE
8304293: RISC-V: JDK-8276799 missed atomic intrinsic support for C1

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -36,6 +36,12 @@ const char* VM_Version::_uarch = "";
 uint32_t VM_Version::_initial_vector_length = 0;
 
 void VM_Version::initialize() {
+  _supports_cx8 = true;
+  _supports_atomic_getset4 = true;
+  _supports_atomic_getadd4 = true;
+  _supports_atomic_getset8 = true;
+  _supports_atomic_getadd8 = true;
+
   get_os_cpu_info();
 
   if (FLAG_IS_DEFAULT(UseFMA)) {


### PR DESCRIPTION
Please review this backport to riscv-port-jdk17u.
Backport of [JDK-8304293](https://bugs.openjdk.org/browse/JDK-8304293).
Let me show the IR changes before and after the modification:
`java -Xcomp -XX:TieredStopAtLevel=1 -XX:+PrintIR -version > C1.log`

before:
```
B3 (V) [33, 49] dom B1 pred: B1
empty stack
inlining depth 0
__bci__use__tid____instr____________________________________
  33   1    a35    <instance 0x00000040c003c3b8 klass=java/util/concurrent/atomic/AtomicLong>
. 8    0    l42    a25.invokespecial(a35, l27, l4)
                   jdk/internal/misc/Unsafe.getAndAddLong(Ljava/lang/Object;JJ)J
  41   1    a46    <instance 0x00000040c003c3c0 klass=java/util/concurrent/atomic/AtomicLong>
  7    1    l53    1L
. 8    0    l54    a25.invokespecial(a46, l27, l53)
                   jdk/internal/misc/Unsafe.getAndAddLong(Ljava/lang/Object;JJ)J
. 49   0    i61    ireturn i29
```

after:
```
B3 (V) [33, 49] dom B1 pred: B1
empty stack
inlining depth 0
__bci__use__tid____instr____________________________________
  33   1    a35    <instance 0x00000040c003c3b8 klass=java/util/concurrent/atomic/AtomicLong>
. 8    0    l42    UnsafeGetAndSetObject (add).(a35, l27, value l4)
  41   1    a46    <instance 0x00000040c003c3c0 klass=java/util/concurrent/atomic/AtomicLong>
  7    1    l53    1L
. 8    0    l54    UnsafeGetAndSetObject (add).(a46, l27, value l53)
. 49   0    i61    ireturn i29
```

Testing:

Tier1 passed without new failure on unmacthed (release).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304293](https://bugs.openjdk.org/browse/JDK-8304293): RISC-V: JDK-8276799 missed atomic intrinsic support for C1


### Reviewers
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk17u.git pull/19/head:pull/19` \
`$ git checkout pull/19`

Update a local copy of the PR: \
`$ git checkout pull/19` \
`$ git pull https://git.openjdk.org/riscv-port-jdk17u.git pull/19/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19`

View PR using the GUI difftool: \
`$ git pr show -t 19`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk17u/pull/19.diff">https://git.openjdk.org/riscv-port-jdk17u/pull/19.diff</a>

</details>
