### PR TITLE
8285711: riscv: RVC: Support disassembler show-bytes option

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -266,12 +266,32 @@ class InternalAddress: public Address {
 class Assembler : public AbstractAssembler {
 public:
 
-  enum { instruction_size = 4 };
+  enum {
+    instruction_size = 4,
+    compressed_instruction_size = 2,
+  };
+
+  // instruction must start at passed address
+  static bool is_compressed_instr(address instr) {
+    // The RISC-V ISA Manual, Section 'Base Instruction-Length Encoding':
+    // Instructions are stored in memory as a sequence of 16-bit little-endian parcels, regardless of
+    // memory system endianness. Parcels forming one instruction are stored at increasing halfword
+    // addresses, with the lowest-addressed parcel holding the lowest-numbered bits in the instruction
+    // specification.
+    if (UseRVC && (((uint16_t *)instr)[0] & 0b11) != 0b11) {
+      // 16-bit instructions have their lowest two bits equal to 0b00, 0b01, or 0b10
+      return true;
+    }
+    // 32-bit instructions have their lowest two bits set to 0b11
+    return false;
+  }
 
   //---<  calculate length of instruction  >---
   // We just use the values set above.
   // instruction must start at passed address
-  static unsigned int instr_len(unsigned char *instr) { return instruction_size; }
+  static unsigned int instr_len(address instr) {
+    return is_compressed_instr(instr) ? compressed_instruction_size : instruction_size;
+  }
 
   //---<  longest instructions  >---
   static unsigned int instr_maxlen() { return instruction_size; }


### PR DESCRIPTION
Backporting RVC-related patches. Applied cleanly.

Tested along with other patches, hotspot tier1\~4 with fastdebug build.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285711](https://bugs.openjdk.org/browse/JDK-8285711): riscv: RVC: Support disassembler show-bytes option


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk17u.git pull/20/head:pull/20` \
`$ git checkout pull/20`

Update a local copy of the PR: \
`$ git checkout pull/20` \
`$ git pull https://git.openjdk.org/riscv-port-jdk17u.git pull/20/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20`

View PR using the GUI difftool: \
`$ git pr show -t 20`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk17u/pull/20.diff">https://git.openjdk.org/riscv-port-jdk17u/pull/20.diff</a>

</details>
