### PR TITLE
8297644: RISC-V: Compilation error when shenandoah is disabled

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -956,11 +956,13 @@ definitions %{
 source_hpp %{
 
 #include "asm/macroAssembler.hpp"
+#include "gc/shared/barrierSetAssembler.hpp"
 #include "gc/shared/cardTable.hpp"
 #include "gc/shared/cardTableBarrierSet.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "opto/addnode.hpp"
 #include "opto/convertnode.hpp"
+#include "runtime/objectMonitor.hpp"
 
 extern RegMask _ANY_REG32_mask;
 extern RegMask _ANY_REG_mask;


### PR DESCRIPTION
Please help review this backport to riscv-port-jdk17u.
Backport of [JDK-8297644](https://bugs.openjdk.org/browse/JDK-8297644). Applies cleanly.
The compilation failed before the modification as follows:
```
Creating support/modules_libs/java.base/server/libjvm.so from 975 file(s)
/home/zifeihan/riscv-port-jdk17u/src/hotspot/cpu/riscv/riscv.ad: In member function 'virtual void MachPrologNode::emit(CodeBuffer&, PhaseRegAlloc*) const':
/home/zifeihan/riscv-port-jdk17u/src/hotspot/cpu/riscv/riscv.ad:1351:7: error: invalid use of incomplete type 'class BarrierSetAssembler'
 1351 |     bs->nmethod_entry_barrier(&_masm);
      |       ^~
In file included from /home/zifeihan/riscv-port-jdk17u/src/hotspot/share/gc/shared/modRefBarrierSet.hpp:28,
                 from /home/zifeihan/riscv-port-jdk17u/src/hotspot/share/gc/shared/cardTableBarrierSet.hpp:29,
                 from /home/zifeihan/riscv-port-jdk17u/src/hotspot/cpu/riscv/riscv.ad:960,
                 from ad_riscv.cpp:31:
/home/zifeihan/riscv-port-jdk17u/src/hotspot/share/gc/shared/barrierSet.hpp:36:7: note: forward declaration of 'class BarrierSetAssembler'
   36 | class BarrierSetAssembler;
      |       ^~~~~~~~~~~~~~~~~~~
...
=== End of repeated output ===

No indication of failed target found.
Hint: Try searching the build log for '] Error'.
Hint: See doc/building.html#troubleshooting for assistance.

make[1]: *** [/home/zifeihan/riscv-port-jdk17u/make/Init.gmk:315: main] Error 2
make: *** [/home/zifeihan/riscv-port-jdk17u/make/Init.gmk:186: default] Error 2
```
Compile normally after fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297644](https://bugs.openjdk.org/browse/JDK-8297644): RISC-V: Compilation error when shenandoah is disabled


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk17u.git pull/22/head:pull/22` \
`$ git checkout pull/22`

Update a local copy of the PR: \
`$ git checkout pull/22` \
`$ git pull https://git.openjdk.org/riscv-port-jdk17u.git pull/22/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22`

View PR using the GUI difftool: \
`$ git pr show -t 22`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk17u/pull/22.diff">https://git.openjdk.org/riscv-port-jdk17u/pull/22.diff</a>

</details>
