### PR TITLE
8294086: RISC-V: Cleanup InstructionMark usages in the backend

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -500,10 +500,9 @@ public:
 
 #define INSN_ENTRY_RELOC(result_type, header)                               \
   result_type header {                                                      \
-    InstructionMark im(this);                                               \
     guarantee(rtype == relocInfo::internal_word_type,                       \
               "only internal_word_type relocs make sense here");            \
-    code_section()->relocate(inst_mark(), InternalAddress(dest).rspec());
+    code_section()->relocate(pc(), InternalAddress(dest).rspec());
 
   // Load/store register (all modes)
 #define INSN(NAME, op, funct3)                                                                     \

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -244,7 +244,6 @@ void MacroAssembler::set_last_Java_frame(Register last_java_sp,
   if (L.is_bound()) {
     set_last_Java_frame(last_java_sp, last_java_fp, target(L), tmp);
   } else {
-    InstructionMark im(this);
     L.add_patch_at(code(), locator());
     set_last_Java_frame(last_java_sp, last_java_fp, pc() /* Patched later */, tmp);
   }
@@ -735,8 +734,7 @@ void MacroAssembler::la(Register Rd, const address &dest) {
 }
 
 void MacroAssembler::la(Register Rd, const Address &adr) {
-  InstructionMark im(this);
-  code_section()->relocate(inst_mark(), adr.rspec());
+  code_section()->relocate(pc(), adr.rspec());
   relocInfo::relocType rtype = adr.rspec().reloc()->type();
 
   switch (adr.getMode()) {
@@ -2736,8 +2734,7 @@ void MacroAssembler::la_patchable(Register reg1, const Address &dest, int32_t &o
   assert(is_valid_riscv64_address(dest.target()), "bad address");
   assert(dest.getMode() == Address::literal, "la_patchable must be applied to a literal address");
 
-  InstructionMark im(this);
-  code_section()->relocate(inst_mark(), dest.rspec());
+  code_section()->relocate(pc(), dest.rspec());
   // RISC-V doesn't compute a page-aligned address, in order to partially
   // compensate for the use of *signed* offsets in its base+disp12
   // addressing mode (RISC-V's PC-relative reach remains asymmetric
@@ -3018,15 +3015,9 @@ void MacroAssembler::get_polling_page(Register dest, relocInfo::relocType rtype)
 
 // Read the polling page.  The address of the polling page must
 // already be in r.
-address MacroAssembler::read_polling_page(Register r, int32_t offset, relocInfo::relocType rtype) {
-  address mark;
-  {
-    InstructionMark im(this);
-    code_section()->relocate(inst_mark(), rtype);
-    lwu(zr, Address(r, offset));
-    mark = inst_mark();
-  }
-  return mark;
+void MacroAssembler::read_polling_page(Register r, int32_t offset, relocInfo::relocType rtype) {
+  code_section()->relocate(pc(), rtype);
+  lwu(zr, Address(r, offset));
 }
 
 void  MacroAssembler::set_narrow_oop(Register dst, jobject obj) {
@@ -3040,9 +3031,8 @@ void  MacroAssembler::set_narrow_oop(Register dst, jobject obj) {
   }
 #endif
   int oop_index = oop_recorder()->find_index(obj);
-  InstructionMark im(this);
   RelocationHolder rspec = oop_Relocation::spec(oop_index);
-  code_section()->relocate(inst_mark(), rspec);
+  code_section()->relocate(pc(), rspec);
   li32(dst, 0xDEADBEEF);
   zero_extend(dst, dst, 32);
 }
@@ -3053,9 +3043,8 @@ void  MacroAssembler::set_narrow_klass(Register dst, Klass* k) {
   int index = oop_recorder()->find_index(k);
   assert(!Universe::heap()->is_in(k), "should not be an oop");
 
-  InstructionMark im(this);
   RelocationHolder rspec = metadata_Relocation::spec(index);
-  code_section()->relocate(inst_mark(), rspec);
+  code_section()->relocate(pc(), rspec);
   narrowKlass nk = CompressedKlassPointers::encode(k);
   li32(dst, nk);
   zero_extend(dst, dst, 32);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -648,7 +648,7 @@ class MacroAssembler: public Assembler {
   void reserved_stack_check();
 
   void get_polling_page(Register dest, relocInfo::relocType rtype);
-  address read_polling_page(Register r, int32_t offset, relocInfo::relocType rtype);
+  void read_polling_page(Register r, int32_t offset, relocInfo::relocType rtype);
 
   address trampoline_call(Address entry, CodeBuffer* cbuf = NULL);
   address ic_call(address entry, jint method_index = 0);


### PR DESCRIPTION
Backport one RVC-related patch (3rd, 8 in total). The remaining patches seem to be linear and cannot be submitted concurrently.

Tested along with remaining RVC patches, hotspot tier1~4 with fastdebug build.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294086](https://bugs.openjdk.org/browse/JDK-8294086): RISC-V: Cleanup InstructionMark usages in the backend


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk17u.git pull/23/head:pull/23` \
`$ git checkout pull/23`

Update a local copy of the PR: \
`$ git checkout pull/23` \
`$ git pull https://git.openjdk.org/riscv-port-jdk17u.git pull/23/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23`

View PR using the GUI difftool: \
`$ git pr show -t 23`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk17u/pull/23.diff">https://git.openjdk.org/riscv-port-jdk17u/pull/23.diff</a>

</details>
