### PR TITLE
8305006: Use correct register in riscv_enc_fast_unlock()

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2419,7 +2419,7 @@ encode %{
 
     // Handle existing monitor.
     __ ld(tmp, Address(oop, oopDesc::mark_offset_in_bytes()));
-    __ andi(t0, disp_hdr, markWord::monitor_value);
+    __ andi(t0, tmp, markWord::monitor_value);
     __ bnez(t0, object_has_monitor);
 
     // Check if it is still a light weight lock, this is true if we


### PR DESCRIPTION
Please help review this backport to riscv-port-jdk17u.
Backport of [JDK-8296136](https://bugs.openjdk.org/browse/JDK-8296136). because JDK-8296136 is already present in 17.0.7(jdk17u-dev repo) and riscv-port-jdk17u too. so I created a new issue for this PR.

Testing:

- Tier1 passed without new failure on qemu (release).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305006](https://bugs.openjdk.org/browse/JDK-8305006): Use correct register in riscv_enc_fast_unlock()


### Reviewers
 * [Vladimir Kempik](https://openjdk.org/census#vkempik) (@VladimirKempik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk17u.git pull/27/head:pull/27` \
`$ git checkout pull/27`

Update a local copy of the PR: \
`$ git checkout pull/27` \
`$ git pull https://git.openjdk.org/riscv-port-jdk17u.git pull/27/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27`

View PR using the GUI difftool: \
`$ git pr show -t 27`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk17u/pull/27.diff">https://git.openjdk.org/riscv-port-jdk17u/pull/27.diff</a>

</details>
