### PR TITLE
8305112: RISC-V: Typo fix for RVC description

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -2116,13 +2116,13 @@ enum Nf {
 //     versions. An example:
 //
 //      CompressibleRegion cr(_masm);
-//      __ add(...);       // this instruction will be compressed into 'c.and' when possible
+//      __ add(...);       // this instruction will be compressed into 'c.add' when possible
 //      {
 //         IncompressibleRegion ir(_masm);
 //         __ add(...);    // this instruction will not be compressed
 //         {
 //            CompressibleRegion cr(_masm);
-//            __ add(...); // this instruction will be compressed into 'c.and' when possible
+//            __ add(...); // this instruction will be compressed into 'c.add' when possible
 //         }
 //      }
 //


### PR DESCRIPTION
Backport the trivial typo fix in the RVC description, mentioned in #28.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305112](https://bugs.openjdk.org/browse/JDK-8305112): RISC-V: Typo fix for RVC description


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk17u.git pull/30/head:pull/30` \
`$ git checkout pull/30`

Update a local copy of the PR: \
`$ git checkout pull/30` \
`$ git pull https://git.openjdk.org/riscv-port-jdk17u.git pull/30/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30`

View PR using the GUI difftool: \
`$ git pr show -t 30`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk17u/pull/30.diff">https://git.openjdk.org/riscv-port-jdk17u/pull/30.diff</a>

</details>
