### PR TITLE
8294492: RISC-V: Use li instead of patchable movptr at non-patchable callsites

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.cpp
@@ -187,30 +187,6 @@ void Assembler::li32(Register Rd, int32_t imm) {
 
 #undef INSN
 
-void Assembler::ret() {
-  jalr(x0, x1, 0);
-}
-
-#define INSN(NAME, REGISTER)                                      \
-  void Assembler::NAME(const address &dest, Register temp) {      \
-    assert_cond(dest != NULL);                                    \
-    assert(temp != noreg, "temp must not be empty register!");    \
-    int64_t distance = dest - pc();                               \
-    if (is_offset_in_range(distance, 32)) {                       \
-      auipc(temp, distance + 0x800);                              \
-      jalr(REGISTER, temp, ((int32_t)distance << 20) >> 20);      \
-    } else {                                                      \
-      int32_t offset = 0;                                         \
-      movptr(temp, dest, offset);                                 \
-      jalr(REGISTER, temp, offset);                               \
-    }                                                             \
-  }
-
-  INSN(call, x1);
-  INSN(tail, x0);
-
-#undef INSN
-
 #define INSN(NAME, REGISTER)                                   \
   void Assembler::NAME(const Address &adr, Register temp) {    \
     switch (adr.getMode()) {                                   \
@@ -233,8 +209,6 @@ void Assembler::ret() {
 
   INSN(j,    x0);
   INSN(jal,  x1);
-  INSN(call, x1);
-  INSN(tail, x0);
 
 #undef INSN
 

--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -316,7 +316,8 @@ public:
       lui(Rd, upper);
       offset = lower;
     } else {
-      movptr(Rd, (address)(uintptr_t)adr.offset(), offset);
+      offset = ((int32_t)adr.offset() << 20) >> 20;
+      li(Rd, adr.offset() - offset);
     }
     add(Rd, Rd, adr.base());
   }
@@ -345,17 +346,6 @@ public:
   void jal(const Address &adr, Register temp = t0);
   void jr(Register Rs);
   void jalr(Register Rs);
-  void ret();
-  void call(const address &dest, Register temp = t0);
-  void call(const Address &adr, Register temp = t0);
-  void tail(const address &dest, Register temp = t0);
-  void tail(const Address &adr, Register temp = t0);
-  void call(Label &l, Register temp) {
-    call(target(l), temp);
-  }
-  void tail(Label &l, Register temp) {
-    tail(target(l), temp);
-  }
 
   static inline uint32_t extract(uint32_t val, unsigned msb, unsigned lsb) {
     assert_cond(msb >= lsb && msb <= 31);

--- a/src/hotspot/cpu/riscv/gc/shenandoah/shenandoahBarrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shenandoah/shenandoahBarrierSetAssembler_riscv.cpp
@@ -281,24 +281,25 @@ void ShenandoahBarrierSetAssembler::load_reference_barrier(MacroAssembler* masm,
   }
 
   __ push_call_clobbered_registers();
+  address target = NULL;
   if (is_strong) {
     if (is_narrow) {
-      __ mv(ra, CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_strong_narrow));
+      target = CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_strong_narrow);
     } else {
-      __ mv(ra, CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_strong));
+      target = CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_strong);
     }
   } else if (is_weak) {
     if (is_narrow) {
-      __ mv(ra, CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_weak_narrow));
+      target = CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_weak_narrow);
     } else {
-      __ mv(ra, CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_weak));
+      target = CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_weak);
     }
   } else {
     assert(is_phantom, "only remaining strength");
     assert(!is_narrow, "phantom access cannot be narrow");
-    __ mv(ra, CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_weak));
+    target = CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_weak);
   }
-  __ jalr(ra);
+  __ call(target);
   __ mv(t0, x10);
   __ pop_call_clobbered_registers();
   __ mv(x10, t0);
@@ -677,29 +678,30 @@ void ShenandoahBarrierSetAssembler::generate_c1_load_reference_barrier_runtime_s
   bool is_weak    = ShenandoahBarrierSet::is_weak_access(decorators);
   bool is_phantom = ShenandoahBarrierSet::is_phantom_access(decorators);
   bool is_native  = ShenandoahBarrierSet::is_native_access(decorators);
+  address target  = NULL;
   if (is_strong) {
     if (is_native) {
-      __ mv(ra, CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_strong));
+      target = CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_strong);
     } else {
       if (UseCompressedOops) {
-        __ mv(ra, CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_strong_narrow));
+        target = CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_strong_narrow);
       } else {
-        __ mv(ra, CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_strong));
+        target = CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_strong);
       }
     }
   } else if (is_weak) {
     assert(!is_native, "weak must not be called off-heap");
     if (UseCompressedOops) {
-      __ mv(ra, CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_weak_narrow));
+      target = CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_weak_narrow);
     } else {
-      __ mv(ra, CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_weak));
+      target = CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_weak);
     }
   } else {
     assert(is_phantom, "only remaining strength");
     assert(is_native, "phantom must only be called off-heap");
-    __ mv(ra, CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_phantom));
+    target = CAST_FROM_FN_PTR(address, ShenandoahRuntime::load_reference_barrier_phantom);
   }
-  __ jalr(ra);
+  __ call(target);
   __ mv(t0, x10);
   __ pop_call_clobbered_registers();
   __ mv(x10, t0);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -584,10 +584,8 @@ void MacroAssembler::emit_static_call_stub() {
 void MacroAssembler::call_VM_leaf_base(address entry_point,
                                        int number_of_arguments,
                                        Label *retaddr) {
-  int32_t offset = 0;
   push_reg(RegSet::of(t0, xmethod), sp);   // push << t0 & xmethod >> to sp
-  movptr(t0, entry_point, offset);
-  jalr(x1, t0, offset);
+  call(entry_point);
   if (retaddr != NULL) {
     bind(*retaddr);
   }

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -512,12 +512,18 @@ class MacroAssembler: public Assembler {
   }
 
   // mv
-  void mv(Register Rd, address addr)          { li(Rd, (int64_t)addr); }
+  void mv(Register Rd, address addr)                  { li(Rd, (int64_t)addr); }
+  void mv(Register Rd, address addr, int32_t &offset) {
+    // Split address into a lower 12-bit sign-extended offset and the remainder,
+    // so that the offset could be encoded in jalr or load/store instruction.
+    offset = ((int32_t)(int64_t)addr << 20) >> 20;
+    li(Rd, (int64_t)addr - offset);
+  }
 
   template<typename T, ENABLE_IF(std::is_integral<T>::value)>
-  inline void mv(Register Rd, T o)            { li(Rd, (int64_t)o); }
+  inline void mv(Register Rd, T o)                    { li(Rd, (int64_t)o); }
 
-  inline void mvw(Register Rd, int32_t imm32) { mv(Rd, imm32); }
+  inline void mvw(Register Rd, int32_t imm32)         { mv(Rd, imm32); }
 
   void mv(Register Rd, Address dest);
   void mv(Register Rd, RegisterOrConstant src);
@@ -816,6 +822,18 @@ class MacroAssembler: public Assembler {
   void vmnot_m(VectorRegister vd, VectorRegister vs);
   void vncvt_x_x_w(VectorRegister vd, VectorRegister vs, VectorMask vm = unmasked);
   void vfneg_v(VectorRegister vd, VectorRegister vs);
+
+  void call(const address dest, Register temp = t0) {
+    assert_cond(dest != NULL);
+    assert(temp != noreg, "temp must not be empty register!");
+    int32_t offset = 0;
+    mv(temp, dest, offset);
+    jalr(x1, temp, offset);
+  }
+
+  void ret() {
+    jalr(x0, x1, 0);
+  }
 
 private:
 

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -651,9 +651,7 @@ class StubGenerator: public StubCodeGenerator {
     assert(frame::arg_reg_save_area_bytes == 0, "not expecting frame reg save area");
 #endif
     BLOCK_COMMENT("call MacroAssembler::debug");
-    int32_t offset = 0;
-    __ movptr(t0, CAST_FROM_FN_PTR(address, MacroAssembler::debug64), offset);
-    __ jalr(x1, t0, offset);
+    __ call(CAST_FROM_FN_PTR(address, MacroAssembler::debug64));
     __ ebreak();
 
     return start;
@@ -3808,9 +3806,7 @@ class StubGenerator: public StubCodeGenerator {
     }
     __ mv(c_rarg0, xthread);
     BLOCK_COMMENT("call runtime_entry");
-    int32_t offset = 0;
-    __ movptr(t0, runtime_entry, offset);
-    __ jalr(x1, t0, offset);
+    __ call(runtime_entry);
 
     // Generate oop map
     OopMap* map = new OopMap(framesize, 0);

--- a/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
@@ -190,8 +190,7 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
       } else {
         fn = CAST_FROM_FN_PTR(address, StubRoutines::dsin());
       }
-      __ mv(t0, fn);
-      __ jalr(t0);
+      __ call(fn);
       break;
     case Interpreter::java_lang_math_cos :
       entry_point = __ pc();
@@ -204,8 +203,7 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
       } else {
         fn = CAST_FROM_FN_PTR(address, StubRoutines::dcos());
       }
-      __ mv(t0, fn);
-      __ jalr(t0);
+      __ call(fn);
       break;
     case Interpreter::java_lang_math_tan :
       entry_point = __ pc();
@@ -218,8 +216,7 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
       } else {
         fn = CAST_FROM_FN_PTR(address, StubRoutines::dtan());
       }
-      __ mv(t0, fn);
-      __ jalr(t0);
+      __ call(fn);
       break;
     case Interpreter::java_lang_math_log :
       entry_point = __ pc();
@@ -232,8 +229,7 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
       } else {
         fn = CAST_FROM_FN_PTR(address, StubRoutines::dlog());
       }
-      __ mv(t0, fn);
-      __ jalr(t0);
+      __ call(fn);
       break;
     case Interpreter::java_lang_math_log10 :
       entry_point = __ pc();
@@ -246,8 +242,7 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
       } else {
         fn = CAST_FROM_FN_PTR(address, StubRoutines::dlog10());
       }
-      __ mv(t0, fn);
-      __ jalr(t0);
+      __ call(fn);
       break;
     case Interpreter::java_lang_math_exp :
       entry_point = __ pc();
@@ -260,8 +255,7 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
       } else {
         fn = CAST_FROM_FN_PTR(address, StubRoutines::dexp());
       }
-      __ mv(t0, fn);
-      __ jalr(t0);
+      __ call(fn);
       break;
     case Interpreter::java_lang_math_pow :
       entry_point = __ pc();
@@ -275,8 +269,7 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
       } else {
         fn = CAST_FROM_FN_PTR(address, StubRoutines::dpow());
       }
-      __ mv(t0, fn);
-      __ jalr(t0);
+      __ call(fn);
       break;
     case Interpreter::java_lang_math_fmaD :
       if (UseFMA) {
@@ -1155,8 +1148,7 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
     // hand.
     //
     __ mv(c_rarg0, xthread);
-    __ mv(t1, CAST_FROM_FN_PTR(address, JavaThread::check_special_condition_for_native_trans));
-    __ jalr(t1);
+    __ call(CAST_FROM_FN_PTR(address, JavaThread::check_special_condition_for_native_trans));
     __ get_method(xmethod);
     __ reinit_heapbase();
     __ bind(Continue);
@@ -1205,8 +1197,7 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
 
     __ push_call_clobbered_registers();
     __ mv(c_rarg0, xthread);
-    __ mv(t1, CAST_FROM_FN_PTR(address, SharedRuntime::reguard_yellow_pages));
-    __ jalr(t1);
+    __ call(CAST_FROM_FN_PTR(address, SharedRuntime::reguard_yellow_pages));
     __ pop_call_clobbered_registers();
     __ bind(no_reguard);
   }

--- a/src/hotspot/cpu/riscv/templateTable_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateTable_riscv.cpp
@@ -403,7 +403,7 @@ void TemplateTable::fast_aldc(bool wide)
 
     // Stash null_sentinel address to get its value later
     int32_t offset = 0;
-    __ movptr(rarg, Universe::the_null_sentinel_addr(), offset);
+    __ mv(rarg, Universe::the_null_sentinel_addr(), offset);
     __ ld(tmp, Address(rarg, offset));
     __ resolve_oop_handle(tmp);
     __ bne(result, tmp, notNull);


### PR DESCRIPTION
Please review this backport to riscv-port-jdk17u.
Backport of [JDK-8294492](https://bugs.openjdk.org/browse/JDK-8294492).
Because there is no [JDK-8293769](https://bugs.openjdk.org/browse/JDK-8293769), [JDK-8296916](https://bugs.openjdk.org/browse/JDK-8296916), [JDK-8294100](https://bugs.openjdk.org/browse/JDK-8294100) here in riscv-port-jdk17u, it will show not clean.

Testing:

Tier1-3 passed without new failure on unmacthed (release).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294492](https://bugs.openjdk.org/browse/JDK-8294492): RISC-V: Use li instead of patchable movptr at non-patchable callsites


### Reviewers
 * [Xiaolin Zheng](https://openjdk.org/census#xlinzheng) (@zhengxiaolinX - Author)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk17u.git pull/37/head:pull/37` \
`$ git checkout pull/37`

Update a local copy of the PR: \
`$ git checkout pull/37` \
`$ git pull https://git.openjdk.org/riscv-port-jdk17u.git pull/37/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 37`

View PR using the GUI difftool: \
`$ git pr show -t 37`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk17u/pull/37.diff">https://git.openjdk.org/riscv-port-jdk17u/pull/37.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/riscv-port-jdk17u/pull/37#issuecomment-1499909423)