### PR TITLE
Backport 2bd24c4542d6a28b8a7829f6db8f80fefd2bce5a

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -1150,7 +1150,7 @@ enum VectorMask {
   }
 
   // Vector Mask
-  INSN(vpopc_m,  0b1010111, 0b010, 0b10000, 0b010000);
+  INSN(vcpop_m,  0b1010111, 0b010, 0b10000, 0b010000);
   INSN(vfirst_m, 0b1010111, 0b010, 0b10001, 0b010000);
 #undef INSN
 
@@ -1296,7 +1296,7 @@ enum VectorMask {
   }
 
   // Vector Single-Width Floating-Point Reduction Instructions
-  INSN(vfredsum_vs,   0b1010111, 0b001, 0b000001);
+  INSN(vfredusum_vs,  0b1010111, 0b001, 0b000001);
   INSN(vfredosum_vs,  0b1010111, 0b001, 0b000011);
   INSN(vfredmin_vs,   0b1010111, 0b001, 0b000101);
   INSN(vfredmax_vs,   0b1010111, 0b001, 0b000111);
@@ -1506,11 +1506,11 @@ enum VectorMask {
 
   // Vector Mask-Register Logical Instructions
   INSN(vmxnor_mm,   0b1010111, 0b010, 0b1, 0b011111);
-  INSN(vmornot_mm,  0b1010111, 0b010, 0b1, 0b011100);
+  INSN(vmorn_mm,    0b1010111, 0b010, 0b1, 0b011100);
   INSN(vmnor_mm,    0b1010111, 0b010, 0b1, 0b011110);
   INSN(vmor_mm,     0b1010111, 0b010, 0b1, 0b011010);
   INSN(vmxor_mm,    0b1010111, 0b010, 0b1, 0b011011);
-  INSN(vmandnot_mm, 0b1010111, 0b010, 0b1, 0b011000);
+  INSN(vmandn_mm,   0b1010111, 0b010, 0b1, 0b011000);
   INSN(vmnand_mm,   0b1010111, 0b010, 0b1, 0b011101);
   INSN(vmand_mm,    0b1010111, 0b010, 0b1, 0b011001);
 
@@ -1610,7 +1610,7 @@ enum Nf {
   }
 
   // Vector Load/Store Instructions
-  INSN(vl1r_v, 0b0000111, 0b01000, 0b1, 0b00, g1);
+  INSN(vl1re8_v, 0b0000111, 0b01000, 0b1, 0b00, g1);
 
 #undef INSN
 
@@ -1631,8 +1631,8 @@ enum Nf {
   }
 
   // Vector Unit-Stride Instructions
-  INSN(vle1_v, 0b0000111, 0b000, 0b01011, 0b00, 0b0);
-  INSN(vse1_v, 0b0100111, 0b000, 0b01011, 0b00, 0b0);
+  INSN(vlm_v, 0b0000111, 0b000, 0b01011, 0b00, 0b0);
+  INSN(vsm_v, 0b0100111, 0b000, 0b01011, 0b00, 0b0);
 
 #undef INSN
 

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -1636,7 +1636,7 @@ void C2_MacroAssembler::reduce_minmax_FD_v(FloatRegister dst,
 
   bind(L_NaN);
   vfmv_s_f(tmp2, src1);
-  vfredsum_vs(tmp1, src2, tmp2);
+  vfredusum_vs(tmp1, src2, tmp2);
 
   bind(L_done);
   vfmv_f_s(dst, tmp1);

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -132,7 +132,7 @@
 
   void unspill(VectorRegister v, int offset) {
     add(t0, sp, offset);
-    vl1r_v(v, t0);
+    vl1re8_v(v, t0);
   }
 
   void spill_copy_vector_stack_to_stack(int src_offset, int dst_offset, int vec_reg_size_in_bytes) {

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -1326,7 +1326,7 @@ int MacroAssembler::pop_vp(unsigned int bitset, Register stack) {
   }
 
   for (int i = count - 1; i >= 0; i--) {
-    vl1r_v(as_VectorRegister(regs[i]), stack);
+    vl1re8_v(as_VectorRegister(regs[i]), stack);
     add(stack, stack, vector_size_in_bytes);
   }
 


### PR DESCRIPTION
Please review this backport to riscv-port-jdk17u.
Backport of [JDK-8295968](https://bugs.openjdk.org/browse/JDK-8295968). Applies cleanly with command `patch`.

Just rename, build success.