### PR TITLE
8296447: RISC-V: Make the operands order of vrsub_vx/vrsub_vi consistent with RVV 1.0 spec

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -1269,8 +1269,6 @@ enum VectorMask {
   INSN(vnmsac_vx, 0b1010111, 0b110, 0b101111);
   INSN(vmacc_vx,  0b1010111, 0b110, 0b101101);
 
-  INSN(vrsub_vx,  0b1010111, 0b100, 0b000011);
-
 #undef INSN
 
 #define INSN(NAME, op, funct3, funct6)                                                             \
@@ -1428,8 +1426,9 @@ enum VectorMask {
   INSN(vand_vx, 0b1010111, 0b100, 0b001001);
 
   // Vector Single-Width Integer Add and Subtract
-  INSN(vsub_vx, 0b1010111, 0b100, 0b000010);
-  INSN(vadd_vx, 0b1010111, 0b100, 0b000000);
+  INSN(vsub_vx,  0b1010111, 0b100, 0b000010);
+  INSN(vadd_vx,  0b1010111, 0b100, 0b000000);
+  INSN(vrsub_vx, 0b1010111, 0b100, 0b000011);
 
 #undef INSN
 
@@ -1470,7 +1469,7 @@ enum VectorMask {
 #define INSN(NAME, op, funct3, funct6)                                                             \
   void NAME(VectorRegister Vd, VectorRegister Vs2, int32_t imm, VectorMask vm = unmasked) {        \
     guarantee(is_imm_in_range(imm, 5, 0), "imm is invalid");                                       \
-    patch_VArith(op, Vd, funct3, (uint32_t)imm & 0x1f, Vs2, vm, funct6);                           \
+    patch_VArith(op, Vd, funct3, (uint32_t)(imm & 0x1f), Vs2, vm, funct6);                         \
   }
 
   INSN(vmsgt_vi,  0b1010111, 0b011, 0b011111);
@@ -1483,16 +1482,7 @@ enum VectorMask {
   INSN(vor_vi,    0b1010111, 0b011, 0b001010);
   INSN(vand_vi,   0b1010111, 0b011, 0b001001);
   INSN(vadd_vi,   0b1010111, 0b011, 0b000000);
-
-#undef INSN
-
-#define INSN(NAME, op, funct3, funct6)                                                             \
-  void NAME(VectorRegister Vd, int32_t imm, VectorRegister Vs2, VectorMask vm = unmasked) {        \
-    guarantee(is_imm_in_range(imm, 5, 0), "imm is invalid");                                       \
-    patch_VArith(op, Vd, funct3, (uint32_t)(imm & 0x1f), Vs2, vm, funct6);                         \
-  }
-
-  INSN(vrsub_vi, 0b1010111, 0b011, 0b000011);
+  INSN(vrsub_vi,  0b1010111, 0b011, 0b000011);
 
 #undef INSN
 

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -146,7 +146,7 @@ instruct vabsB(vReg dst, vReg src, vReg tmp) %{
             "vmax.vv $dst, $tmp, $src" %}
   ins_encode %{
     __ vsetvli(t0, x0, Assembler::e8);
-    __ vrsub_vi(as_VectorRegister($tmp$$reg), 0, as_VectorRegister($src$$reg));
+    __ vrsub_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($src$$reg), 0);
     __ vmax_vv(as_VectorRegister($dst$$reg), as_VectorRegister($tmp$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -160,7 +160,7 @@ instruct vabsS(vReg dst, vReg src, vReg tmp) %{
             "vmax.vv $dst, $tmp, $src" %}
   ins_encode %{
     __ vsetvli(t0, x0, Assembler::e16);
-    __ vrsub_vi(as_VectorRegister($tmp$$reg), 0, as_VectorRegister($src$$reg));
+    __ vrsub_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($src$$reg), 0);
     __ vmax_vv(as_VectorRegister($dst$$reg), as_VectorRegister($tmp$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -174,7 +174,7 @@ instruct vabsI(vReg dst, vReg src, vReg tmp) %{
             "vmax.vv $dst, $tmp, $src" %}
   ins_encode %{
     __ vsetvli(t0, x0, Assembler::e32);
-    __ vrsub_vi(as_VectorRegister($tmp$$reg), 0, as_VectorRegister($src$$reg));
+    __ vrsub_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($src$$reg), 0);
     __ vmax_vv(as_VectorRegister($dst$$reg), as_VectorRegister($tmp$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
@@ -188,7 +188,7 @@ instruct vabsL(vReg dst, vReg src, vReg tmp) %{
             "vmax.vv $dst, $tmp, $src" %}
   ins_encode %{
     __ vsetvli(t0, x0, Assembler::e64);
-    __ vrsub_vi(as_VectorRegister($tmp$$reg), 0, as_VectorRegister($src$$reg));
+    __ vrsub_vi(as_VectorRegister($tmp$$reg), as_VectorRegister($src$$reg), 0);
     __ vmax_vv(as_VectorRegister($dst$$reg), as_VectorRegister($tmp$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);


### PR DESCRIPTION
Please review this backport to riscv-port-jdk17u.
Backport of [JDK-8296447](https://bugs.openjdk.org/browse/JDK-8296447). 
A little conflict is that we do not have the `vneg_v` in `macroAssembler_riscv.cpp`

Tested:
- jdk/incubator/vector (release/fastdebug with UseRVV on QEMU)
- tier1 (release with UseRVV on QEMU)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296447](https://bugs.openjdk.org/browse/JDK-8296447): RISC-V: Make the operands order of vrsub_vx/vrsub_vi consistent with RVV 1.0 spec


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk17u.git pull/41/head:pull/41` \
`$ git checkout pull/41`

Update a local copy of the PR: \
`$ git checkout pull/41` \
`$ git pull https://git.openjdk.org/riscv-port-jdk17u.git pull/41/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 41`

View PR using the GUI difftool: \
`$ git pr show -t 41`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk17u/pull/41.diff">https://git.openjdk.org/riscv-port-jdk17u/pull/41.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/riscv-port-jdk17u/pull/41#issuecomment-1504933418)