### PR TITLE
8294012: RISC-V: get/put_native_u8 missing the case when address&7 is 6

### DIFF
--- a/src/hotspot/cpu/riscv/bytes_riscv.hpp
+++ b/src/hotspot/cpu/riscv/bytes_riscv.hpp
@@ -75,6 +75,7 @@ class Bytes: AllStatic {
                ((u8)(((u4*)p)[0]));
 
       case 2:
+      case 6:
         return ((u8)(((u2*)p)[3]) << 48) |
                ((u8)(((u2*)p)[2]) << 32) |
                ((u8)(((u2*)p)[1]) << 16) |
@@ -133,6 +134,7 @@ class Bytes: AllStatic {
         break;
 
       case 2:
+      case 6:
         ((u2*)p)[3] = x >> 48;
         ((u2*)p)[2] = x >> 32;
         ((u2*)p)[1] = x >> 16;


### PR DESCRIPTION
Please review this backport to riscv-port-jdk17u.
Backport of [JDK-8294012](https://bugs.openjdk.org/browse/JDK-8294012). Applies cleanly.

Testing:

Tier1-3 passed without new failure on unmacthed (release).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294012](https://bugs.openjdk.org/browse/JDK-8294012): RISC-V: get/put_native_u8 missing the case when address&amp;7 is 6


### Reviewers
 * [Vladimir Kempik](https://openjdk.org/census#vkempik) (@VladimirKempik - no project role)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk17u.git pull/46/head:pull/46` \
`$ git checkout pull/46`

Update a local copy of the PR: \
`$ git checkout pull/46` \
`$ git pull https://git.openjdk.org/riscv-port-jdk17u.git pull/46/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 46`

View PR using the GUI difftool: \
`$ git pr show -t 46`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk17u/pull/46.diff">https://git.openjdk.org/riscv-port-jdk17u/pull/46.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/riscv-port-jdk17u/pull/46#issuecomment-1515635237)