### PR TITLE
8297359: RISC-V: improve performance of floating Max Min intrinsics

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -1296,26 +1296,27 @@ void C2_MacroAssembler::minmax_FD(FloatRegister dst, FloatRegister src1, FloatRe
                                   bool is_double, bool is_min) {
   assert_different_registers(dst, src1, src2);
 
-  Label Done;
-  fsflags(zr);
+  Label Done, Compare;
+
+  is_double ? fclass_d(t0, src1)
+            : fclass_s(t0, src1);
+  is_double ? fclass_d(t1, src2)
+            : fclass_s(t1, src2);
+  orr(t0, t0, t1);
+  andi(t0, t0, 0b1100000000); //if src1 or src2 is quiet or signaling NaN then return NaN
+  beqz(t0, Compare);
+  is_double ? fadd_d(dst, src1, src2)
+            : fadd_s(dst, src1, src2);
+  j(Done);
+
+  bind(Compare);
   if (is_double) {
     is_min ? fmin_d(dst, src1, src2)
            : fmax_d(dst, src1, src2);
-    // Checking NaNs
-    flt_d(zr, src1, src2);
   } else {
     is_min ? fmin_s(dst, src1, src2)
            : fmax_s(dst, src1, src2);
-    // Checking NaNs
-    flt_s(zr, src1, src2);
   }
-
-  frflags(t0);
-  beqz(t0, Done);
-
-  // In case of NaNs
-  is_double ? fadd_d(dst, src1, src2)
-            : fadd_s(dst, src1, src2);
 
   bind(Done);
 }

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -7200,9 +7200,9 @@ instruct nmaddD_reg_reg(fRegD dst, fRegD src1, fRegD src2, fRegD src3) %{
 %}
 
 // Math.max(FF)F
-instruct maxF_reg_reg(fRegF dst, fRegF src1, fRegF src2) %{
+instruct maxF_reg_reg(fRegF dst, fRegF src1, fRegF src2, rFlagsReg cr) %{
   match(Set dst (MaxF src1 src2));
-  effect(TEMP_DEF dst);
+  effect(TEMP_DEF dst, KILL cr);
 
   format %{ "maxF $dst, $src1, $src2" %}
 
@@ -7216,9 +7216,9 @@ instruct maxF_reg_reg(fRegF dst, fRegF src1, fRegF src2) %{
 %}
 
 // Math.min(FF)F
-instruct minF_reg_reg(fRegF dst, fRegF src1, fRegF src2) %{
+instruct minF_reg_reg(fRegF dst, fRegF src1, fRegF src2, rFlagsReg cr) %{
   match(Set dst (MinF src1 src2));
-  effect(TEMP_DEF dst);
+  effect(TEMP_DEF dst, KILL cr);
 
   format %{ "minF $dst, $src1, $src2" %}
 
@@ -7232,9 +7232,9 @@ instruct minF_reg_reg(fRegF dst, fRegF src1, fRegF src2) %{
 %}
 
 // Math.max(DD)D
-instruct maxD_reg_reg(fRegD dst, fRegD src1, fRegD src2) %{
+instruct maxD_reg_reg(fRegD dst, fRegD src1, fRegD src2, rFlagsReg cr) %{
   match(Set dst (MaxD src1 src2));
-  effect(TEMP_DEF dst);
+  effect(TEMP_DEF dst, KILL cr);
 
   format %{ "maxD $dst, $src1, $src2" %}
 
@@ -7248,9 +7248,9 @@ instruct maxD_reg_reg(fRegD dst, fRegD src1, fRegD src2) %{
 %}
 
 // Math.min(DD)D
-instruct minD_reg_reg(fRegD dst, fRegD src1, fRegD src2) %{
+instruct minD_reg_reg(fRegD dst, fRegD src1, fRegD src2, rFlagsReg cr) %{
   match(Set dst (MinD src1 src2));
-  effect(TEMP_DEF dst);
+  effect(TEMP_DEF dst, KILL cr);
 
   format %{ "minD $dst, $src1, $src2" %}
 


### PR DESCRIPTION
Please review this clean backport of JDK-[8297359](https://bugs.openjdk.org/browse/JDK-8297359) to jdk17u riscv port dev
This significantly improves performance of fp min/max instrinsics.
Results are same as in upstream jdk - https://mail.openjdk.org/pipermail/riscv-port-dev/2022-November/000684.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297359](https://bugs.openjdk.org/browse/JDK-8297359): RISC-V: improve performance of floating Max Min intrinsics


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk17u.git pull/49/head:pull/49` \
`$ git checkout pull/49`

Update a local copy of the PR: \
`$ git checkout pull/49` \
`$ git pull https://git.openjdk.org/riscv-port-jdk17u.git pull/49/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 49`

View PR using the GUI difftool: \
`$ git pr show -t 49`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk17u/pull/49.diff">https://git.openjdk.org/riscv-port-jdk17u/pull/49.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/riscv-port-jdk17u/pull/49#issuecomment-1528157967)