### PR TITLE
8308089: [riscv-port-jdk17u] Intrinsify Unsafe.storeStoreFence

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -7736,6 +7736,7 @@ instruct membar_release() %{
 
 instruct membar_storestore() %{
   match(MemBarStoreStore);
+  match(StoreStoreFence);
   ins_cost(ALU_COST);
 
   format %{ "MEMBAR-store-store\t#@membar_storestore" %}


### PR DESCRIPTION
[JDK-8252990](https://bugs.openjdk.org/browse/JDK-8252990) was recently backported to jdk17u in April. We should also enable the matching rule for `StoreStoreFence` on the WIP riscv-port-jdk17u repo.

Found the small fastdebug crash when backporting #51 using `-Xcomp`.

Testing a hotspot tier1\~2 in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308089](https://bugs.openjdk.org/browse/JDK-8308089): [riscv-port-jdk17u] Intrinsify Unsafe.storeStoreFence


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk17u.git pull/52/head:pull/52` \
`$ git checkout pull/52`

Update a local copy of the PR: \
`$ git checkout pull/52` \
`$ git pull https://git.openjdk.org/riscv-port-jdk17u.git pull/52/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 52`

View PR using the GUI difftool: \
`$ git pr show -t 52`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk17u/pull/52.diff">https://git.openjdk.org/riscv-port-jdk17u/pull/52.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/riscv-port-jdk17u/pull/52#issuecomment-1547613153)