### PR TITLE
8307150: RISC-V: Remove remaining StoreLoad barrier with UseCondCardMark for Serial/Parallel GC

### DIFF
--- a/src/hotspot/cpu/riscv/gc/shared/cardTableBarrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shared/cardTableBarrierSetAssembler_riscv.cpp
@@ -49,7 +49,6 @@ void CardTableBarrierSetAssembler::store_check(MacroAssembler* masm, Register ob
 
   if (UseCondCardMark) {
     Label L_already_dirty;
-    __ membar(MacroAssembler::StoreLoad);
     __ lbu(t1,  Address(tmp));
     __ beqz(t1, L_already_dirty);
     __ sb(zr, Address(tmp));


### PR DESCRIPTION
Hi,
Please review this clean backport of [JDK-8307150](https://bugs.openjdk.org/browse/JDK-8307150) to riscv-port-jdk17u.
Same as the mainline, this `StoreLoad` barrier is no longer needed after the removal of CMS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307150](https://bugs.openjdk.org/browse/JDK-8307150): RISC-V: Remove remaining StoreLoad barrier with UseCondCardMark for Serial/Parallel GC


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk17u.git pull/55/head:pull/55` \
`$ git checkout pull/55`

Update a local copy of the PR: \
`$ git checkout pull/55` \
`$ git pull https://git.openjdk.org/riscv-port-jdk17u.git pull/55/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 55`

View PR using the GUI difftool: \
`$ git pr show -t 55`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk17u/pull/55.diff">https://git.openjdk.org/riscv-port-jdk17u/pull/55.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/riscv-port-jdk17u/pull/55#issuecomment-1556464019)