### PR TITLE
8307446: RISC-V: Improve performance of floating point to integer conversion

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -4201,24 +4201,23 @@ void MacroAssembler::fill_words(Register base, Register cnt, Register value) {
   bind(fini);
 }
 
-#define FCVT_SAFE(FLOATCVT, FLOATEQ)                                                             \
-void MacroAssembler:: FLOATCVT##_safe(Register dst, FloatRegister src, Register tmp) {           \
-  Label L_Okay;                                                                                  \
-  fscsr(zr);                                                                                     \
-  FLOATCVT(dst, src);                                                                            \
-  frcsr(tmp);                                                                                    \
-  andi(tmp, tmp, 0x1E);                                                                          \
-  beqz(tmp, L_Okay);                                                                             \
-  FLOATEQ(tmp, src, src);                                                                        \
-  bnez(tmp, L_Okay);                                                                             \
-  mv(dst, zr);                                                                                   \
-  bind(L_Okay);                                                                                  \
+#define FCVT_SAFE(FLOATCVT, FLOATSIG)                                                     \
+void MacroAssembler::FLOATCVT##_safe(Register dst, FloatRegister src, Register tmp) {     \
+  Label done;                                                                             \
+  assert_different_registers(dst, tmp);                                                   \
+  fclass_##FLOATSIG(tmp, src);                                                            \
+  mv(dst, zr);                                                                            \
+  /* check if src is NaN */                                                               \
+  andi(tmp, tmp, 0b1100000000);                                                           \
+  bnez(tmp, done);                                                                        \
+  FLOATCVT(dst, src);                                                                     \
+  bind(done);                                                                             \
 }
 
-FCVT_SAFE(fcvt_w_s, feq_s)
-FCVT_SAFE(fcvt_l_s, feq_s)
-FCVT_SAFE(fcvt_w_d, feq_d)
-FCVT_SAFE(fcvt_l_d, feq_d)
+FCVT_SAFE(fcvt_w_s, s);
+FCVT_SAFE(fcvt_l_s, s);
+FCVT_SAFE(fcvt_w_d, d);
+FCVT_SAFE(fcvt_l_d, d);
 
 #undef FCVT_SAFE
 


### PR DESCRIPTION
Hi,
please review this clean backport of [JDK-8307446](https://bugs.openjdk.org/browse/JDK-8307446).

JHM shows the same improvement on Unmatched board:

```
Benchmark                     (size)   Mode  Cnt   Score   Error   Units
--- baseline -----------------------------------------------------------
FloatConversion.doubleToInt     2048  thrpt   15  30.270 ? 0.144  ops/ms
FloatConversion.doubleToLong    2048  thrpt   15  29.831 ? 0.128  ops/ms
FloatConversion.floatToInt      2048  thrpt   15  30.530 ? 0.031  ops/ms
FloatConversion.floatToLong     2048  thrpt   15  30.189 ? 0.100  ops/ms
--- optimized ----------------------------------------------------------
FloatConversion.doubleToInt     2048  thrpt   15  66.051 ? 0.064  ops/ms
FloatConversion.doubleToLong    2048  thrpt   15  66.095 ? 0.460  ops/ms
FloatConversion.floatToInt      2048  thrpt   15  68.114 ? 0.072  ops/ms
FloatConversion.floatToLong     2048  thrpt   15  68.482 ? 0.193  ops/ms
```

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307446](https://bugs.openjdk.org/browse/JDK-8307446): RISC-V: Improve performance of floating point to integer conversion


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk17u.git pull/57/head:pull/57` \
`$ git checkout pull/57`

Update a local copy of the PR: \
`$ git checkout pull/57` \
`$ git pull https://git.openjdk.org/riscv-port-jdk17u.git pull/57/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 57`

View PR using the GUI difftool: \
`$ git pr show -t 57`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk17u/pull/57.diff">https://git.openjdk.org/riscv-port-jdk17u/pull/57.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/riscv-port-jdk17u/pull/57#issuecomment-1557046557)