### PR TITLE
8308277: RISC-V: Improve vectorization of Match.sqrt() on floats

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -7384,7 +7384,7 @@ instruct absD_reg(fRegD dst, fRegD src) %{
 %}
 
 instruct sqrtF_reg(fRegF dst, fRegF src) %{
-  match(Set dst (ConvD2F (SqrtD (ConvF2D src))));
+  match(Set dst (SqrtF src));
 
   ins_cost(FSQRT_COST);
   format %{ "fsqrt.s  $dst, $src\t#@sqrtF_reg" %}


### PR DESCRIPTION
Hi,
Please review this clean backport of [JDK-8308277](https://bugs.openjdk.org/browse/JDK-8308277).

For jdk17u, `Math.sqrt(float)` will not get vectorized even when `UseRVV` is true without the `SqrtF` node.

Here is the OptoAssembly of Sqrt.java from [JDK-8190800](https://bugs.openjdk.org/browse/JDK-8190800):

before:
```
120     B14: #  out( B14 B15 ) <- in( B13 B14 ) Loop( B14-B14 inner main of N91 strip mined) Freq: 1.86254e+07
120 +   addw  R28, R12, zr  #@convI2L_reg_reg
124 +   slli  R28, R28, (#2 & 0x3f) #@lShiftL_reg_imm
128 +   add R28, R18, R28   # ptr, #@addP_reg_reg
12c +   flw  F0, [R28, #16] # float, #@loadF
130 +   fsqrt.s  F1, F0 #@sqrtF_reg
134 +   fsw  F1, [R28, #16] # float, #@storeF
```

after:
```
140     B14: #  out( B14 B15 ) <- in( B13 B14 ) Loop( B14-B14 inner main of N93 strip mined) Freq: 1.60517e+07
140     addw  R10, R31, zr  #@convI2L_reg_reg
144     slli  R10, R10, (#2 & 0x3f) #@lShiftL_reg_imm
148     add R11, R9, R10    # ptr, #@addP_reg_reg
14c     addi  R10, R11, #16 # ptr, #@addP_reg_imm
150     vle V1, [R10]   #@loadV
158     vfsqrt.v V1, V1 #@vsqrtF
160     addi  R10, R11, #16 # ptr, #@addP_reg_imm
164     vse V1, [R10]   #@storeV
```

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308277](https://bugs.openjdk.org/browse/JDK-8308277): RISC-V: Improve vectorization of Match.sqrt() on floats


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk17u.git pull/58/head:pull/58` \
`$ git checkout pull/58`

Update a local copy of the PR: \
`$ git checkout pull/58` \
`$ git pull https://git.openjdk.org/riscv-port-jdk17u.git pull/58/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 58`

View PR using the GUI difftool: \
`$ git pr show -t 58`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk17u/pull/58.diff">https://git.openjdk.org/riscv-port-jdk17u/pull/58.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/riscv-port-jdk17u/pull/58#issuecomment-1557049325)