### PR TITLE
8301628: RISC-V: c2 fix pipeline class for several instructions

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -940,8 +940,8 @@ definitions %{
   int_def IMUL_COST            ( 1000, 10 * DEFAULT_COST);          // imul
   int_def IDIVSI_COST          ( 3400, 34 * DEFAULT_COST);          // idivdi
   int_def IDIVDI_COST          ( 6600, 66 * DEFAULT_COST);          // idivsi
-  int_def FMUL_SINGLE_COST     (  500,  5 * DEFAULT_COST);          // fadd, fmul, fmadd
-  int_def FMUL_DOUBLE_COST     (  700,  7 * DEFAULT_COST);          // fadd, fmul, fmadd
+  int_def FMUL_SINGLE_COST     (  500,  5 * DEFAULT_COST);          // fmul, fmadd
+  int_def FMUL_DOUBLE_COST     (  700,  7 * DEFAULT_COST);          // fmul, fmadd
   int_def FDIV_COST            ( 2000, 20 * DEFAULT_COST);          // fdiv
   int_def FSQRT_COST           ( 2500, 25 * DEFAULT_COST);          // fsqrt
   int_def VOLATILE_REF_COST    ( 1000, 10 * DEFAULT_COST);
@@ -6940,7 +6940,7 @@ instruct regI_not_reg(iRegINoSp dst, iRegI src1, immI_M1 m1) %{
     __ xori(as_Register($dst$$reg), as_Register($src1$$reg), -1);
   %}
 
-  ins_pipe(ialu_reg);
+  ins_pipe(ialu_reg_imm);
 %}
 
 instruct regL_not_reg(iRegLNoSp dst, iRegL src1, immL_M1 m1) %{
@@ -6952,7 +6952,7 @@ instruct regL_not_reg(iRegLNoSp dst, iRegL src1, immL_M1 m1) %{
     __ xori(as_Register($dst$$reg), as_Register($src1$$reg), -1);
   %}
 
-  ins_pipe(ialu_reg);
+  ins_pipe(ialu_reg_imm);
 %}
 
 
@@ -6962,7 +6962,7 @@ instruct regL_not_reg(iRegLNoSp dst, iRegL src1, immL_M1 m1) %{
 instruct addF_reg_reg(fRegF dst, fRegF src1, fRegF src2) %{
   match(Set dst (AddF src1 src2));
 
-  ins_cost(FMUL_SINGLE_COST);
+  ins_cost(DEFAULT_COST * 5);
   format %{ "fadd.s  $dst, $src1, $src2\t#@addF_reg_reg" %}
 
   ins_encode %{
@@ -6977,7 +6977,7 @@ instruct addF_reg_reg(fRegF dst, fRegF src1, fRegF src2) %{
 instruct addD_reg_reg(fRegD dst, fRegD src1, fRegD src2) %{
   match(Set dst (AddD src1 src2));
 
-  ins_cost(FMUL_DOUBLE_COST);
+  ins_cost(DEFAULT_COST * 5);
   format %{ "fadd.d  $dst, $src1, $src2\t#@addD_reg_reg" %}
 
   ins_encode %{
@@ -6992,7 +6992,7 @@ instruct addD_reg_reg(fRegD dst, fRegD src1, fRegD src2) %{
 instruct subF_reg_reg(fRegF dst, fRegF src1, fRegF src2) %{
   match(Set dst (SubF src1 src2));
 
-  ins_cost(FMUL_SINGLE_COST);
+  ins_cost(DEFAULT_COST * 5);
   format %{ "fsub.s  $dst, $src1, $src2\t#@subF_reg_reg" %}
 
   ins_encode %{
@@ -7007,7 +7007,7 @@ instruct subF_reg_reg(fRegF dst, fRegF src1, fRegF src2) %{
 instruct subD_reg_reg(fRegD dst, fRegD src1, fRegD src2) %{
   match(Set dst (SubD src1 src2));
 
-  ins_cost(FMUL_DOUBLE_COST);
+  ins_cost(DEFAULT_COST * 5);
   format %{ "fsub.d  $dst, $src1, $src2\t#@subD_reg_reg" %}
 
   ins_encode %{
@@ -7210,7 +7210,7 @@ instruct maxF_reg_reg(fRegF dst, fRegF src1, fRegF src2, rFlagsReg cr) %{
                  false /* is_double */, false /* is_min */);
   %}
 
-  ins_pipe(fp_dop_reg_reg_s);
+  ins_pipe(pipe_class_default);
 %}
 
 // Math.min(FF)F
@@ -7226,7 +7226,7 @@ instruct minF_reg_reg(fRegF dst, fRegF src1, fRegF src2, rFlagsReg cr) %{
                  false /* is_double */, true /* is_min */);
   %}
 
-  ins_pipe(fp_dop_reg_reg_s);
+  ins_pipe(pipe_class_default);
 %}
 
 // Math.max(DD)D
@@ -7242,7 +7242,7 @@ instruct maxD_reg_reg(fRegD dst, fRegD src1, fRegD src2, rFlagsReg cr) %{
                  true /* is_double */, false /* is_min */);
   %}
 
-  ins_pipe(fp_dop_reg_reg_d);
+  ins_pipe(pipe_class_default);
 %}
 
 // Math.min(DD)D
@@ -7258,7 +7258,7 @@ instruct minD_reg_reg(fRegD dst, fRegD src1, fRegD src2, rFlagsReg cr) %{
                  true /* is_double */, true /* is_min */);
   %}
 
-  ins_pipe(fp_dop_reg_reg_d);
+  ins_pipe(pipe_class_default);
 %}
 
 instruct divF_reg_reg(fRegF dst, fRegF src1, fRegF src2) %{


### PR DESCRIPTION
Hi, please review this backport to riscv-port-jdk17u.
Backport of [JDK-8301628](https://bugs.openjdk.org/browse/JDK-8301628).
The original patch cannot be directly applied because jdk17u has no [JDK-8293695](https://bugs.openjdk.org/browse/JDK-8293695).

Testing:
- Tier1-3 passed without new failure on unmacthed (release).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301628](https://bugs.openjdk.org/browse/JDK-8301628): RISC-V: c2 fix pipeline class for several instructions


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk17u.git pull/59/head:pull/59` \
`$ git checkout pull/59`

Update a local copy of the PR: \
`$ git checkout pull/59` \
`$ git pull https://git.openjdk.org/riscv-port-jdk17u.git pull/59/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 59`

View PR using the GUI difftool: \
`$ git pr show -t 59`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk17u/pull/59.diff">https://git.openjdk.org/riscv-port-jdk17u/pull/59.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/riscv-port-jdk17u/pull/59#issuecomment-1558454545)