### PR TITLE
8301153: RISC-V: pipeline class for several instructions is not set correctly

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -4160,7 +4160,7 @@ pipe_class imul_reg_reg(iRegI dst, iRegI src1, iRegI src2)
 %}
 
 // E.g. MUL   RD, Rs1, Rs2
-pipe_class lmul_reg_reg(iRegI dst, iRegI src1, iRegI src2)
+pipe_class lmul_reg_reg(iRegL dst, iRegL src1, iRegL src2)
 %{
   single_instruction;
   fixed_latency(3); // Maximum latency for 64 bit mul
@@ -4186,7 +4186,7 @@ pipe_class idiv_reg_reg(iRegI dst, iRegI src1, iRegI src2)
 %}
 
 // E.g. DIV   RD, Rs1, Rs2
-pipe_class ldiv_reg_reg(iRegI dst, iRegI src1, iRegI src2)
+pipe_class ldiv_reg_reg(iRegL dst, iRegL src1, iRegL src2)
 %{
   single_instruction;
   fixed_latency(16); // Maximum latency for 64 bit divide
@@ -7335,7 +7335,7 @@ instruct absI_reg(iRegINoSp dst, iRegIorL2I src) %{
     __ xorr(as_Register($dst$$reg), as_Register($dst$$reg), t0);
   %}
 
-  ins_pipe(ialu_reg_reg);
+  ins_pipe(pipe_class_default);
 %}
 
 instruct absL_reg(iRegLNoSp dst, iRegL src) %{
@@ -7354,7 +7354,7 @@ instruct absL_reg(iRegLNoSp dst, iRegL src) %{
     __ xorr(as_Register($dst$$reg), as_Register($dst$$reg), t0);
   %}
 
-  ins_pipe(ialu_reg_reg);
+  ins_pipe(pipe_class_default);
 %}
 
 instruct absF_reg(fRegF dst, fRegF src) %{
@@ -7611,7 +7611,7 @@ instruct xorL_reg_imm(iRegLNoSp dst, iRegL src1, immLAdd src2) %{
 
 instruct bytes_reverse_int(iRegINoSp dst, iRegIorL2I src, rFlagsReg cr) %{
   match(Set dst (ReverseBytesI src));
-  effect(TEMP cr);
+  effect(KILL cr);
 
   ins_cost(ALU_COST * 13);
   format %{ "revb_w_w  $dst, $src\t#@bytes_reverse_int" %}
@@ -7620,12 +7620,12 @@ instruct bytes_reverse_int(iRegINoSp dst, iRegIorL2I src, rFlagsReg cr) %{
     __ revb_w_w(as_Register($dst$$reg), as_Register($src$$reg));
   %}
 
-  ins_pipe(ialu_reg);
+  ins_pipe(pipe_class_default);
 %}
 
 instruct bytes_reverse_long(iRegLNoSp dst, iRegL src, rFlagsReg cr) %{
   match(Set dst (ReverseBytesL src));
-  effect(TEMP cr);
+  effect(KILL cr);
 
   ins_cost(ALU_COST * 29);
   format %{ "revb  $dst, $src\t#@bytes_reverse_long" %}
@@ -7634,7 +7634,7 @@ instruct bytes_reverse_long(iRegLNoSp dst, iRegL src, rFlagsReg cr) %{
     __ revb(as_Register($dst$$reg), as_Register($src$$reg));
   %}
 
-  ins_pipe(ialu_reg);
+  ins_pipe(pipe_class_default);
 %}
 
 instruct bytes_reverse_unsigned_short(iRegINoSp dst, iRegIorL2I src) %{
@@ -7647,7 +7647,7 @@ instruct bytes_reverse_unsigned_short(iRegINoSp dst, iRegIorL2I src) %{
     __ revb_h_h_u(as_Register($dst$$reg), as_Register($src$$reg));
   %}
 
-  ins_pipe(ialu_reg);
+  ins_pipe(pipe_class_default);
 %}
 
 instruct bytes_reverse_short(iRegINoSp dst, iRegIorL2I src) %{
@@ -7660,7 +7660,7 @@ instruct bytes_reverse_short(iRegINoSp dst, iRegIorL2I src) %{
     __ revb_h_h(as_Register($dst$$reg), as_Register($src$$reg));
   %}
 
-  ins_pipe(ialu_reg);
+  ins_pipe(pipe_class_default);
 %}
 
 // ============================================================================
@@ -8139,7 +8139,7 @@ instruct encodeHeapOop(iRegNNoSp dst, iRegP src) %{
     Register d = $dst$$Register;
     __ encode_heap_oop(d, s);
   %}
-  ins_pipe(ialu_reg);
+  ins_pipe(pipe_class_default);
 %}
 
 instruct decodeHeapOop(iRegPNoSp dst, iRegN src) %{
@@ -8154,7 +8154,7 @@ instruct decodeHeapOop(iRegPNoSp dst, iRegN src) %{
     Register d = $dst$$Register;
     __ decode_heap_oop(d, s);
   %}
-  ins_pipe(ialu_reg);
+  ins_pipe(pipe_class_default);
 %}
 
 instruct decodeHeapOop_not_null(iRegPNoSp dst, iRegN src) %{
@@ -8169,7 +8169,7 @@ instruct decodeHeapOop_not_null(iRegPNoSp dst, iRegN src) %{
     Register d = $dst$$Register;
     __ decode_heap_oop_not_null(d, s);
   %}
-  ins_pipe(ialu_reg);
+  ins_pipe(pipe_class_default);
 %}
 
 // Convert klass pointer into compressed form.
@@ -8185,7 +8185,7 @@ instruct encodeKlass_not_null(iRegNNoSp dst, iRegP src) %{
     __ encode_klass_not_null(dst_reg, src_reg, t0);
   %}
 
-   ins_pipe(ialu_reg);
+   ins_pipe(pipe_class_default);
 %}
 
 instruct decodeKlass_not_null(iRegPNoSp dst, iRegN src, iRegPNoSp tmp) %{
@@ -8203,7 +8203,7 @@ instruct decodeKlass_not_null(iRegPNoSp dst, iRegN src, iRegPNoSp tmp) %{
     __ decode_klass_not_null(dst_reg, src_reg, tmp_reg);
   %}
 
-   ins_pipe(ialu_reg);
+   ins_pipe(pipe_class_default);
 %}
 
 // stack <-> reg and reg <-> reg shuffles with no conversion
@@ -8240,7 +8240,7 @@ instruct MoveI2F_stack_reg(fRegF dst, stackSlotI src) %{
     __ flw(as_FloatRegister($dst$$reg), Address(sp, $src$$disp));
   %}
 
-  ins_pipe(pipe_class_memory);
+  ins_pipe(fp_load_mem_s);
 
 %}
 
@@ -8276,7 +8276,7 @@ instruct MoveL2D_stack_reg(fRegD dst, stackSlotL src) %{
     __ fld(as_FloatRegister($dst$$reg), Address(sp, $src$$disp));
   %}
 
-  ins_pipe(pipe_class_memory);
+  ins_pipe(fp_load_mem_d);
 
 %}
 
@@ -8294,7 +8294,7 @@ instruct MoveF2I_reg_stack(stackSlotI dst, fRegF src) %{
     __ fsw(as_FloatRegister($src$$reg), Address(sp, $dst$$disp));
   %}
 
-  ins_pipe(pipe_class_memory);
+  ins_pipe(fp_store_reg_s);
 
 %}
 
@@ -8330,7 +8330,7 @@ instruct MoveD2L_reg_stack(stackSlotL dst, fRegD src) %{
     __ fsd(as_FloatRegister($src$$reg), Address(sp, $dst$$disp));
   %}
 
-  ins_pipe(pipe_class_memory);
+  ins_pipe(fp_store_reg_d);
 
 %}
 
@@ -8421,6 +8421,7 @@ instruct MoveL2D_reg_reg(fRegD dst, iRegL src) %{
   %}
 
   ins_pipe(fp_l2d);
+
 %}
 
 // ============================================================================


### PR DESCRIPTION
Hi,
Please review this backport to riscv-port-jdk17u.
Backport of [JDK-8301153](https://bugs.openjdk.org/browse/JDK-8301153). Applies cleanly.

Testing:

Tier1-3 passed without new failure on unmacthed (release).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301153](https://bugs.openjdk.org/browse/JDK-8301153): RISC-V: pipeline class for several instructions is not set correctly


### Reviewers
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Author)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk17u.git pull/61/head:pull/61` \
`$ git checkout pull/61`

Update a local copy of the PR: \
`$ git checkout pull/61` \
`$ git pull https://git.openjdk.org/riscv-port-jdk17u.git pull/61/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 61`

View PR using the GUI difftool: \
`$ git pr show -t 61`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk17u/pull/61.diff">https://git.openjdk.org/riscv-port-jdk17u/pull/61.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/riscv-port-jdk17u/pull/61#issuecomment-1561437620)