### PR TITLE
8302289: RISC-V: Use bgez instruction in arraycopy_simple_check when possible

### DIFF
--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_arraycopy_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_arraycopy_riscv.cpp
@@ -92,18 +92,17 @@ void LIR_Assembler::arraycopy_simple_check(Register src, Register src_pos, Regis
   // of the arraycopy is an array type, check at runtime if the source or the destination is
   // an instance type.
   if (flags & LIR_OpArrayCopy::type_check) {
+    assert(Klass::_lh_neutral_value == 0, "or replace bgez instructions");
     if (!(flags & LIR_OpArrayCopy::LIR_OpArrayCopy::dst_objarray)) {
       __ load_klass(tmp, dst);
       __ lw(t0, Address(tmp, in_bytes(Klass::layout_helper_offset())));
-      __ mv(t1, Klass::_lh_neutral_value);
-      __ bge(t0, t1, *stub->entry(), /* is_far */ true);
+      __ bgez(t0, *stub->entry(), /* is_far */ true);
     }
 
     if (!(flags & LIR_OpArrayCopy::LIR_OpArrayCopy::src_objarray)) {
       __ load_klass(tmp, src);
       __ lw(t0, Address(tmp, in_bytes(Klass::layout_helper_offset())));
-      __ mv(t1, Klass::_lh_neutral_value);
-      __ bge(t0, t1, *stub->entry(), /* is_far */ true);
+      __ bgez(t0, *stub->entry(), /* is_far */ true);
     }
   }
 


### PR DESCRIPTION
Hi,
Please help review this backport to riscv-port-jdk17u.
Backport of [JDK-8302289](https://bugs.openjdk.org/browse/JDK-8302289). Applies cleanly.

Testing:

Tier1-3 passed without new failure on unmacthed (release).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302289](https://bugs.openjdk.org/browse/JDK-8302289): RISC-V: Use bgez instruction in arraycopy_simple_check when possible


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk17u.git pull/64/head:pull/64` \
`$ git checkout pull/64`

Update a local copy of the PR: \
`$ git checkout pull/64` \
`$ git pull https://git.openjdk.org/riscv-port-jdk17u.git pull/64/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 64`

View PR using the GUI difftool: \
`$ git pr show -t 64`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk17u/pull/64.diff">https://git.openjdk.org/riscv-port-jdk17u/pull/64.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/riscv-port-jdk17u/pull/64#issuecomment-1569553239)