### PR TITLE
8301033: RISC-V: Handle special cases for MinI/MaxI nodes for Zbb

### DIFF
--- a/src/hotspot/cpu/riscv/riscv_b.ad
+++ b/src/hotspot/cpu/riscv/riscv_b.ad
@@ -395,12 +395,12 @@ instruct popCountL_b(iRegINoSp dst, iRegL src) %{
 %}
 
 // Max and Min
-instruct minI_reg_b(iRegINoSp dst, iRegI src1, iRegI src2) %{
+instruct minI_reg_reg_b(iRegINoSp dst, iRegI src1, iRegI src2) %{
   predicate(UseZbb);
   match(Set dst (MinI src1 src2));
 
   ins_cost(ALU_COST);
-  format %{ "min  $dst, $src1, $src2\t#@minI_reg_b" %}
+  format %{ "min  $dst, $src1, $src2\t#@minI_reg_reg_b" %}
 
   ins_encode %{
     __ min(as_Register($dst$$reg), as_Register($src1$$reg), as_Register($src2$$reg));
@@ -409,15 +409,49 @@ instruct minI_reg_b(iRegINoSp dst, iRegI src1, iRegI src2) %{
   ins_pipe(ialu_reg_reg);
 %}
 
-instruct maxI_reg_b(iRegINoSp dst, iRegI src1, iRegI src2) %{
+instruct maxI_reg_reg_b(iRegINoSp dst, iRegI src1, iRegI src2) %{
   predicate(UseZbb);
   match(Set dst (MaxI src1 src2));
 
   ins_cost(ALU_COST);
-  format %{ "max  $dst, $src1, $src2\t#@maxI_reg_b" %}
+  format %{ "max  $dst, $src1, $src2\t#@maxI_reg_reg_b" %}
 
   ins_encode %{
     __ max(as_Register($dst$$reg), as_Register($src1$$reg), as_Register($src2$$reg));
+  %}
+
+  ins_pipe(ialu_reg_reg);
+%}
+
+// special case for comparing with zero
+// n.b. this is selected in preference to the rule above because it
+// avoids loading constant 0 into a source register
+
+instruct minI_reg_zero_b(iRegINoSp dst, iRegI src1, immI0 zero) %{
+  predicate(UseZbb);
+  match(Set dst (MinI src1 zero));
+  match(Set dst (MinI zero src1));
+
+  ins_cost(ALU_COST);
+  format %{ "min  $dst, $src1, zr\t#@minI_reg_zero_b" %}
+
+  ins_encode %{
+    __ min(as_Register($dst$$reg), as_Register($src1$$reg), zr);
+  %}
+
+  ins_pipe(ialu_reg_reg);
+%}
+
+instruct maxI_reg_zero_b(iRegINoSp dst, iRegI src1, immI0 zero) %{
+  predicate(UseZbb);
+  match(Set dst (MaxI src1 zero));
+  match(Set dst (MaxI zero src1));
+
+  ins_cost(ALU_COST);
+  format %{ "max  $dst, $src1, zr\t#@maxI_reg_zero_b" %}
+
+  ins_encode %{
+    __ max(as_Register($dst$$reg), as_Register($src1$$reg), zr);
   %}
 
   ins_pipe(ialu_reg_reg);


### PR DESCRIPTION
Hi, please review this backport to riscv-port-jdk17u.
Backport of [JDK-8301033](https://bugs.openjdk.org/browse/JDK-8301033). Applies cleanly.

The difference in -XX:+PrintOptoAssembly output looks like:
Before:
```
048 li R7, #0 # int, #@loadConI
04a + max R10, R12, R7 #@maxI_reg_b
04e # pop frame 32
```

After:
```
048 max R10, R12, zr #@maxI_reg_zero_b
04c # pop frame 32
```

Before:
```
028 li R7, #0 # int, #@loadConI
02a + min R10, R11, R7 #@minI_reg_b
02e # pop frame 32
```

After:
```
028 min R10, R11, zr #@minI_reg_zero_b
02c # pop frame 32
```

Testing:
- https://github.com/openjdk/jdk/blob/master/test/hotspot/jtreg/compiler/intrinsics/math/TestMinMaxIntrinsics.java
- tier1-3 tests on QEMU-System w/ and w/o UseZbb (release build)
- tier1-3 tests on unmatched board w/o UseZbb (release build)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301033](https://bugs.openjdk.org/browse/JDK-8301033): RISC-V: Handle special cases for MinI/MaxI nodes for Zbb


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk17u.git pull/66/head:pull/66` \
`$ git checkout pull/66`

Update a local copy of the PR: \
`$ git checkout pull/66` \
`$ git pull https://git.openjdk.org/riscv-port-jdk17u.git pull/66/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 66`

View PR using the GUI difftool: \
`$ git pr show -t 66`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk17u/pull/66.diff">https://git.openjdk.org/riscv-port-jdk17u/pull/66.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/riscv-port-jdk17u/pull/66#issuecomment-1573028563)