### PR TITLE
8309427: [riscv-port-jdk17u] Remove unused RoundDoubleModeV C2 node

### DIFF
--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -1101,34 +1101,6 @@ instruct vreduce_minD(fRegD dst, fRegD src1, vReg src2, vReg tmp1, vReg tmp2) %{
   ins_pipe(pipe_slow);
 %}
 
-// vector Math.rint, floor, ceil
-
-instruct vroundD(vReg dst, vReg src, immI rmode) %{
-  predicate(n->bottom_type()->is_vect()->element_basic_type() == T_DOUBLE);
-  match(Set dst (RoundDoubleModeV src rmode));
-  format %{ "vroundD $dst, $src, $rmode" %}
-  ins_encode %{
-    switch ($rmode$$constant) {
-      case RoundDoubleModeNode::rmode_rint:
-        __ csrwi(CSR_FRM, C2_MacroAssembler::rne);
-        __ vfcvt_rtz_x_f_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
-        break;
-      case RoundDoubleModeNode::rmode_floor:
-        __ csrwi(CSR_FRM, C2_MacroAssembler::rdn);
-        __ vfcvt_rtz_x_f_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
-        break;
-      case RoundDoubleModeNode::rmode_ceil:
-        __ csrwi(CSR_FRM, C2_MacroAssembler::rup);
-        __ vfcvt_rtz_x_f_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
-        break;
-      default:
-        ShouldNotReachHere();
-        break;
-    }
-  %}
-  ins_pipe(pipe_slow);
-%}
-
 // vector replicate
 
 instruct replicateB(vReg dst, iRegIorL2I src) %{


### PR DESCRIPTION
Hi, here we want to remove the RoundDoubleModeV node that is not being used, we found that the reason the RoundDoubleModeV node is not called in RISC-V is that the PopulateIndex node needs to be added to enable SuperWord optimization (an algorithm for automatic vectorization). In addition to this, the node RoundDoubleMode needs to be implemented in its scalar form, which is not implemented in riscv.ad. But there is no floating point to floating point instruction in riscv that does not change the width by, so what we need to do here may simply be to remove the RoundDoubleModeV node. refer: https://bugs.openjdk.org/browse/JDK-8298342

Testing:

Tier1-3 passed without new failure on unmacthed (release).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309427](https://bugs.openjdk.org/browse/JDK-8309427): [riscv-port-jdk17u] Remove unused RoundDoubleModeV C2 node (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/riscv-port-jdk17u.git pull/68/head:pull/68` \
`$ git checkout pull/68`

Update a local copy of the PR: \
`$ git checkout pull/68` \
`$ git pull https://git.openjdk.org/riscv-port-jdk17u.git pull/68/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 68`

View PR using the GUI difftool: \
`$ git pr show -t 68`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/riscv-port-jdk17u/pull/68.diff">https://git.openjdk.org/riscv-port-jdk17u/pull/68.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/riscv-port-jdk17u/pull/68#issuecomment-1576228263)